### PR TITLE
OD-288 [Fix] Users won't see any error message when select '-- Select data source' and press 'See all data sources' 

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -693,7 +693,7 @@ __webpack_require__.r(__webpack_exports__);
 
         _this3.hasAccessRules();
 
-        _this2.dataSources = _this2.formatDataSources();
+        _this3.dataSources = _this3.formatDataSources();
         Fliplet.Widget.emit('dataSourceSelect', dataSource);
       })["catch"](function (err) {
         _this3.showError(Fliplet.parseError(err));

--- a/dist/app.js
+++ b/dist/app.js
@@ -754,7 +754,7 @@ __webpack_require__.r(__webpack_exports__);
       var _this5 = this;
 
       Object(_services_dataSource__WEBPACK_IMPORTED_MODULE_1__["getDataSources"])(appId).then(function (dataSources) {
-        if (_this5.widgetData.dataSourceId) {
+        if (_this5.widgetData.dataSourceId && _this5.selectedDataSource) {
           var selectedDataSourceFound = dataSources.some(function (dataSource) {
             return dataSource.id === _this5.selectedDataSource.id;
           });

--- a/src/DataSourceProvider.vue
+++ b/src/DataSourceProvider.vue
@@ -291,7 +291,7 @@ export default {
     loadDataSources(appId) {
       getDataSources(appId)
         .then(dataSources => {
-          if (this.widgetData.dataSourceId) {
+          if (this.widgetData.dataSourceId && this.selectedDataSource) {
             const selectedDataSourceFound = dataSources.some(dataSource => {
               return dataSource.id === this.selectedDataSource.id;
             });


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://weboo.atlassian.net/browse/OD-288

## Description
To avoid showing an error, we should check that `this.selectedDatasource` isn't a `null` which means that the user selects a '-- Select data source'.

## Screenshots/screencasts
https://share.getcloudapp.com/OAuWgRzR

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko