### PR TITLE
OD-276 [Fix] Users wont see duplicated rules when set default rules with data source provider

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -623,8 +623,10 @@ __webpack_require__.r(__webpack_exports__);
 
       this.isLoading = true;
 
+      var defaultRules = _.cloneDeep(this.widgetData.accessRules);
+
       if (this.selectedDataSource.accessRules && this.selectedDataSource.accessRules.length > 0) {
-        this.widgetData.accessRules.forEach(function (defaultRule) {
+        defaultRules.forEach(function (defaultRule) {
           defaultRule.type = _this.missingAccessTypes;
           defaultRule.enabled = true;
 

--- a/dist/app.js
+++ b/dist/app.js
@@ -693,7 +693,7 @@ __webpack_require__.r(__webpack_exports__);
 
         _this3.hasAccessRules();
 
-        _this2.dataSources = _this2.formatDataSources();
+        _this3.dataSources = _this3.formatDataSources();
         Fliplet.Widget.emit('dataSourceSelect', dataSource);
       })["catch"](function (err) {
         _this3.showError(Fliplet.parseError(err));

--- a/src/DataSourceProvider.vue
+++ b/src/DataSourceProvider.vue
@@ -153,9 +153,10 @@ export default {
     },
     onAddDefaultSecurity() {
       this.isLoading = true;
+      const defaultRules = _.cloneDeep(this.widgetData.accessRules);
 
       if (this.selectedDataSource.accessRules && this.selectedDataSource.accessRules.length > 0) {
-        this.widgetData.accessRules.forEach(defaultRule => {
+        defaultRules.forEach(defaultRule => {
           defaultRule.type = this.missingAccessTypes;
           defaultRule.enabled = true;
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://weboo.atlassian.net/browse/OD-276

## Description
Using a deep copy of the default access rules to add missing rule types and avoid mutating the original access rules array.

## Screenshots/screencasts
https://share.getcloudapp.com/wbuK6KxK

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko