### PR TITLE
ID-9 [Fix] Allow provider be initialized with access rules

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -753,7 +753,7 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
       var includedAccessTypes = [];
       this.missingAccessTypes = [];
       this.selectedDataSource.accessRules.forEach(function (dataSourceRules) {
-        _this4.widgetData.accessRules.forEach(function (componentRules) {
+        _.forEach(_this4.widgetData.accessRules, function (componentRules) {
           componentRules.type.forEach(function (componentType) {
             if (_.includes(dataSourceRules.type, componentType) && dataSourceRules.enabled && (!dataSourceRules.appId || _.includes(dataSourceRules.appId, _this4.widgetData.appId))) {
               includedAccessTypes.push(componentType);
@@ -762,13 +762,15 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
         });
       });
       includedAccessTypes = _.uniq(includedAccessTypes);
-      this.widgetData.accessRules.forEach(function (defaultRule) {
+
+      _.forEach(this.widgetData.accessRules, function (defaultRule) {
         defaultRule.type.forEach(function (defaultType) {
           if (!_.includes(includedAccessTypes, defaultType)) {
             _this4.missingAccessTypes.push(defaultType);
           }
         });
       });
+
       this.missingAccessTypes = _.uniq(this.missingAccessTypes);
 
       if (this.missingAccessTypes.length) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2183,9 +2183,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
-      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
     "babel-eslint": {
@@ -6317,18 +6317,18 @@
       }
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.48.0.tgz",
+      "integrity": "sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.31",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.31.tgz",
+      "integrity": "sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==",
       "dev": true,
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.48.0"
       }
     },
     "mimic-fn": {
@@ -10147,9 +10147,9 @@
           }
         },
         "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
           "dev": true
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gulp": "^4.0.2",
     "gulp-sass": "^4.0.2",
     "gulp-vueify2": "0.0.3",
-    "node-sass": "^4.12.0",
+    "node-sass": "^4.14.1",
     "path": "^0.12.7",
     "sass-loader": "^7.1.0",
     "style-loader": "^0.23.1",

--- a/src/DataSourceProvider.vue
+++ b/src/DataSourceProvider.vue
@@ -291,7 +291,7 @@ export default {
       this.missingAccessTypes = [];
 
       this.selectedDataSource.accessRules.forEach(dataSourceRules => {
-        this.widgetData.accessRules.forEach(componentRules => {
+        _.forEach(this.widgetData.accessRules, componentRules => {
           componentRules.type.forEach(componentType => {
             if (
               _.includes(dataSourceRules.type, componentType)
@@ -306,7 +306,7 @@ export default {
 
       includedAccessTypes = _.uniq(includedAccessTypes);
 
-      this.widgetData.accessRules.forEach(defaultRule => {
+      _.forEach(this.widgetData.accessRules, defaultRule => {
         defaultRule.type.forEach(defaultType => {
           if (!_.includes(includedAccessTypes, defaultType)) {
             this.missingAccessTypes.push(defaultType);


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-9

When `accessRules` isn't provided, an error is triggered. This fix prevents the problem by using lodash functions instead to fail silently.