### PR TITLE
OD-606 [Fix] Aligning data source fields

### DIFF
--- a/src/scss/dataSourceProvider.scss
+++ b/src/scss/dataSourceProvider.scss
@@ -7,6 +7,7 @@
   overflow: hidden;
   position: relative;
   padding: 0;
+  min-width: 100%;
 }
 
 .alert {


### PR DESCRIPTION
@sofiiakvasnevska @inna-bieshulia

OD-606 https://weboo.atlassian.net/browse/OD-606

## Description
Fixed wrong alignment of data source fields
**Problem:** Default Bootstrap style was limiting "container" width according to iframe size.
**Solution:** Manually set minimal width for "container" class to override Bootstrap behavior.

## Screenshots/screencasts
https://storyxpress.co/video/ksrkin0rayyr4c27d

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko 