### PR TITLE
OD-531 [FIX] Fixed error of displaying the datasource provider

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -1029,6 +1029,10 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
 
             break;
 
+          case 'show-widget':
+            Fliplet.Widget.autosize();
+            break;
+
           default:
             break;
         }

--- a/dist/app.js
+++ b/dist/app.js
@@ -1029,7 +1029,7 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
 
             break;
 
-          case 'show-widget':
+          case 'widget-autosize':
             Fliplet.Widget.autosize();
             break;
 

--- a/dist/app.js
+++ b/dist/app.js
@@ -1009,6 +1009,8 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
       });
     });
     Fliplet.Studio.onMessage(function (event) {
+      console.log(event);
+
       if (event.data) {
         switch (event.data.event) {
           case 'overlay-close':
@@ -1030,6 +1032,7 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
             break;
 
           case 'widget-autosize':
+            console.log('in');
             Fliplet.Widget.autosize();
             break;
 

--- a/dist/app.js
+++ b/dist/app.js
@@ -1009,8 +1009,6 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
       });
     });
     Fliplet.Studio.onMessage(function (event) {
-      console.log(event);
-
       if (event.data) {
         switch (event.data.event) {
           case 'overlay-close':
@@ -1032,7 +1030,6 @@ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { va
             break;
 
           case 'widget-autosize':
-            console.log('in');
             Fliplet.Widget.autosize();
             break;
 

--- a/src/DataSourceProvider.vue
+++ b/src/DataSourceProvider.vue
@@ -574,7 +574,7 @@ export default {
             }
 
             break;
-          case 'show-widget':
+          case 'widget-autosize':
             Fliplet.Widget.autosize();
 
             break;

--- a/src/DataSourceProvider.vue
+++ b/src/DataSourceProvider.vue
@@ -556,8 +556,6 @@ export default {
     });
 
     Fliplet.Studio.onMessage(event => {
-      console.log(event);
-
       if (event.data) {
         switch (event.data.event) {
           case 'overlay-close':
@@ -577,8 +575,6 @@ export default {
 
             break;
           case 'widget-autosize':
-            console.log('in');
-
             Fliplet.Widget.autosize();
 
             break;

--- a/src/DataSourceProvider.vue
+++ b/src/DataSourceProvider.vue
@@ -576,6 +576,7 @@ export default {
             break;
           case 'show-widget':
             Fliplet.Widget.autosize();
+
             break;
           default:
             break;

--- a/src/DataSourceProvider.vue
+++ b/src/DataSourceProvider.vue
@@ -556,6 +556,8 @@ export default {
     });
 
     Fliplet.Studio.onMessage(event => {
+      console.log(event);
+
       if (event.data) {
         switch (event.data.event) {
           case 'overlay-close':
@@ -575,6 +577,8 @@ export default {
 
             break;
           case 'widget-autosize':
+            console.log('in');
+
             Fliplet.Widget.autosize();
 
             break;

--- a/src/DataSourceProvider.vue
+++ b/src/DataSourceProvider.vue
@@ -574,6 +574,9 @@ export default {
             }
 
             break;
+          case 'show-widget':
+            Fliplet.Widget.autosize();
+            break;
           default:
             break;
         }


### PR DESCRIPTION
@sofiiakvasnevska

OD-531 https://weboo.atlassian.net/browse/OD-531

## Description
**Problem:** If in the component settings you switch tabs before loading the datasource provider, it will not be assigned a height.
**Solution:** When a tab is opened, an event is emit to a provider that triggers the Fliplet.Widget.autosize() function inside the provider

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko