### PR TITLE
OD-279 [Fix] Hiding the "Missing security rules" modal when clicking outside.

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -1005,6 +1005,7 @@ var required = window.validators.required;
       Fliplet.Modal.confirm({
         title: 'Missing security rules',
         message: message,
+        backdrop: true,
         buttons: {
           confirm: {
             label: 'Add security rule'

--- a/src/DataSourceProvider.vue
+++ b/src/DataSourceProvider.vue
@@ -544,6 +544,7 @@ export default {
       Fliplet.Modal.confirm({
         title: 'Missing security rules',
         message: message,
+        backdrop: true,
         buttons: {
           confirm: {
             label: 'Add security rule'


### PR DESCRIPTION
@romanyosyfiv @inna-bieshulia

OD-279 https://weboo.atlassian.net/browse/OD-279

## Description
**Problem:** When `Fliplet.Modal.confirm` is called, the required property is not passed, which will hide the popup when clicked outside.
**Solution:** The property `backdrop: true` has been added to the call to the modal window.

## Screenshots/screencasts
https://storyxpress.co/video/kv82nbybxdswce6rc

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko