### PR TITLE
XOR-7 [FEAT] Ensure excludeTypes param added in datasource GET call

### DIFF
--- a/dist/app.js
+++ b/dist/app.js
@@ -123,7 +123,7 @@ var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_
   null,
   null,
   null
-  
+
 )
 
 /* hot reload */
@@ -463,7 +463,7 @@ render._withStripped = true
 "use strict";
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_index_js_vue_loader_options_DataSourceProvider_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(5);
-/* empty/unused harmony star reexport */ /* harmony default export */ __webpack_exports__["default"] = (_node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_index_js_vue_loader_options_DataSourceProvider_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__["default"]); 
+/* empty/unused harmony star reexport */ /* harmony default export */ __webpack_exports__["default"] = (_node_modules_babel_loader_lib_index_js_ref_3_0_node_modules_vue_loader_lib_index_js_vue_loader_options_DataSourceProvider_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__["default"]);
 
 /***/ }),
 /* 5 */
@@ -1241,6 +1241,7 @@ var getDataSources = function getDataSources(appId) {
   if (appId) {
     getOptions.appId = appId;
     getOptions.includeInUse = true;
+    getOptions.excludeTypes = 'bookmarks,likes,comments';
   }
 
   return Fliplet.DataSources.get(getOptions);

--- a/src/services/dataSource.js
+++ b/src/services/dataSource.js
@@ -4,6 +4,7 @@ export const getDataSources = appId => {
   if (appId) {
     getOptions.appId = appId;
     getOptions.includeInUse = true;
+    getOptions.excludeTypes = 'bookmarks,likes,comments';
   }
 
   return Fliplet.DataSources.get(getOptions);

--- a/src/services/dataSource.js
+++ b/src/services/dataSource.js
@@ -4,7 +4,7 @@ export const getDataSources = appId => {
   if (appId) {
     getOptions.appId = appId;
     getOptions.includeInUse = true;
-    getOptions.excludeTypes = 'bookmarks,likes,comments';
+    getOptions.excludeTypes = 'bookmarks,likes,comments,menu';
   }
 
   return Fliplet.DataSources.get(getOptions);


### PR DESCRIPTION
### Product areas affected

API - GET `v1/data-sources` API 

### What does this PR do?

Update GET `v1/data-sources` API - add excludeTypes query param support which can accept data source type separated by comma e.g. excludeTypes=bookmarks,likes,comments,menu

### JIRA ticket

[XOR-7](https://weboo.atlassian.net/browse/XOR-7)

### Result



https://user-images.githubusercontent.com/101858104/174721701-70eae059-52e5-466e-a260-934c2799db1d.mp4


### Checklist

None

### Deployment instructions

None

### Author concerns

None